### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # repeat-element [![NPM version](https://badge.fury.io/js/repeat-element.svg)](http://badge.fury.io/js/repeat-element)
 
-> Create an array by repeating the given string n times.
+> Create an array by repeating a given value n times.
 
 ## Install with [npm](npmjs.org)
 


### PR DESCRIPTION
It seems it’s not only strings that work:

``` js
repeat(null, 5)
//» [ null, null, null, null, null ]

repeat({some: 'object'}, 5)
//» [ { some: 'object' },
//    { some: 'object' },
//    { some: 'object' },
//    { some: 'object' },
//    { some: 'object' } ]

repeat(5, 5)
//» [ 5, 5, 5, 5, 5 ]
```
