### PR TITLE
Use SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/jonschlinkert/repeat-element/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/jonschlinkert/repeat-element/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
From [npm’s documentation](https://docs.npmjs.com/files/package.json#license):

> Some old packages used license objects or a "licenses" property containing an array of license objects … Those styles are now deprecated. Instead, use SPDX expressions.